### PR TITLE
Fixes React warning in Calendar component

### DIFF
--- a/demos/03-add-msgraph/graph-tutorial/src/Calendar.js
+++ b/demos/03-add-msgraph/graph-tutorial/src/Calendar.js
@@ -46,9 +46,9 @@ export default class Calendar extends React.Component {
           </thead>
           <tbody>
             {this.state.events.map(
-              function(event, index){
+              function(event){
                 return(
-                  <tr>
+                  <tr key={event.id}>
                     <td>{event.organizer.emailAddress.name}</td>
                     <td>{event.subject}</td>
                     <td>{formatDateTime(event.start.dateTime)}</td>


### PR DESCRIPTION
React at the moment complains in console (Warning: Each child in an array or iterator should have a unique "key" prop) in Calendar page (refer [official documentation](https://reactjs.org/docs/lists-and-keys.html#keys) for a more details why this warning appears).

This PR adds a unique key to event row in Calendar component to resolve it.