### PR TITLE
Added code to set redirect explicitly

### DIFF
--- a/demos/02-add-aad-auth/graph-tutorial/src/App.js
+++ b/demos/02-add-aad-auth/graph-tutorial/src/App.js
@@ -15,7 +15,8 @@ class App extends Component {
 
     this.userAgentApplication = new UserAgentApplication({
         auth: {
-            clientId: config.appId
+            clientId: config.appId,
+            redirectUri: config.redirectUri
         },
         cache: {
             cacheLocation: "localStorage",

--- a/demos/02-add-aad-auth/graph-tutorial/src/Config.js.example
+++ b/demos/02-add-aad-auth/graph-tutorial/src/Config.js.example
@@ -1,7 +1,8 @@
 module.exports = {
   appId: 'YOUR_APP_ID_HERE',
+  redirectUri: 'https://localhost:3000',
   scopes: [
-    "user.read",
-    "calendars.read"
+    'user.read',
+    'calendars.read'
   ]
 };

--- a/demos/03-add-msgraph/graph-tutorial/src/App.js
+++ b/demos/03-add-msgraph/graph-tutorial/src/App.js
@@ -14,9 +14,12 @@ class App extends Component {
   constructor(props) {
     super(props);
 
+    console.log(JSON.stringify(props));
+
     this.userAgentApplication = new UserAgentApplication({
         auth: {
-            clientId: config.appId
+            clientId: config.appId,
+            redirectUri: config.redirectUri
         },
         cache: {
             cacheLocation: "localStorage",

--- a/demos/03-add-msgraph/graph-tutorial/src/Config.js.example
+++ b/demos/03-add-msgraph/graph-tutorial/src/Config.js.example
@@ -1,7 +1,8 @@
 module.exports = {
   appId: 'YOUR_APP_ID_HERE',
+  redirectUri: 'https://localhost:3000',
   scopes: [
-    "user.read",
-    "calendars.read"
+    'user.read',
+    'calendars.read'
   ]
 };

--- a/tutorial/04-add-aad-auth.md
+++ b/tutorial/04-add-aad-auth.md
@@ -7,9 +7,10 @@ Create a new file in the `./src` directory named `Config.js` and add the followi
 ```js
 module.exports = {
   appId: 'YOUR_APP_ID_HERE',
+  redirectUri: 'https://localhost:3000',
   scopes: [
-    "user.read",
-    "calendars.read"
+    'user.read',
+    'calendars.read'
   ]
 };
 ```
@@ -36,7 +37,8 @@ constructor(props) {
 
   this.userAgentApplication = new UserAgentApplication({
         auth: {
-            clientId: config.appId
+            clientId: config.appId,
+            redirectUri: config.redirectUri
         },
         cache: {
             cacheLocation: "localStorage",


### PR DESCRIPTION
Resolves an error when refreshing the token from the calendar page. In that case, MSAL uses the URL of the calendar page as the redirect when refreshing the token. Because that URL does not match the registered redirect, it fails.

Related to #24 