### PR TITLE
fix: create events with correct end datetime

### DIFF
--- a/demo/graph-tutorial/src/NewEvent.tsx
+++ b/demo/graph-tutorial/src/NewEvent.tsx
@@ -87,7 +87,7 @@ class NewEvent extends React.Component<AuthComponentProps, NewEventState> {
         timeZone: this.props.user.timeZone
       },
       end: {
-        dateTime: this.state.start,
+        dateTime: this.state.end,
         timeZone: this.props.user.timeZone
       },
       // Only add if a body was given


### PR DESCRIPTION
Fixed a minor typo in `NewEvent.tsx` so that the demo correctly creates a calendar event from start to end time.