### PR TITLE
Provided default value for time zone

### DIFF
--- a/demo/graph-tutorial/src/AuthProvider.tsx
+++ b/demo/graph-tutorial/src/AuthProvider.tsx
@@ -142,7 +142,7 @@ export default function withAuthProvider<T extends React.Component<AuthComponent
             user: {
               displayName: user.displayName,
               email: user.mail || user.userPrincipalName,
-              timeZone: user.mailboxSettings.timeZone,
+              timeZone: user.mailboxSettings.timeZone || 'UTC',
               timeFormat: user.mailboxSettings.timeFormat
             },
             error: null


### PR DESCRIPTION
Covers case when a user does not have it defined in their mailbox settings.

Fixes #60